### PR TITLE
Emulate LDAX address bus side effect so Kill the Bit works (#1)

### DIFF
--- a/doc/kill_the_bit.md
+++ b/doc/kill_the_bit.md
@@ -1,0 +1,131 @@
+# Kill the Bit (GitHub issue #1)
+
+## The issue
+
+[Issue #1](https://github.com/wixette/8800-simulator/issues/1) reports
+that *Kill the Bit* — the classic Altair 8800 game written by Dean
+McDaniel in 1975 — does not work in the simulator: while the program
+runs, no address or data LED lights up and the sense switches appear
+to do nothing. Reference listing: <https://altairclone.com/downloads/killbits.pdf>.
+
+```
+        ; Kill the Bit game by Dean McDaniel, May 15, 1975
+        ;
+        ; Object: Kill the rotating bit. If you miss the lit bit,
+        ; another bit turns on, leaving two bits to destroy. Quickly
+        ; toggle the switch, don't leave the switch in the up position.
+        ; Before starting, make sure all the switches are in the down
+        ; position.
+0000            org     0
+0000 210000     lxi     h,0     ;initialize counter
+0003 1680       mvi     d,080h  ;set up initial display bit
+0005 010E00     lxi     b,0eh   ;higher value = faster
+0008 1A    beg: ldax    d       ;display bit pattern on
+0009 1A         ldax    d       ;...upper 8 address lights
+000A 1A         ldax    d
+000B 1A         ldax    d
+000C 09         dad     b       ;increment display counter
+000D D20800     jnc     beg
+0010 DBFF       in      0ffh    ;input data from sense switches
+0012 AA         xra     d       ;exclusive or with A
+0013 0F         rrc             ;rotate display right one bit
+0014 57         mov     d,a     ;move data to display reg
+0015 C30800     jmp     beg     ;repeat sequence
+0018            end
+```
+
+## Root cause
+
+The game's display depends on a hardware side effect of the real
+Altair 8800: every memory access puts its address on the address bus,
+and the front panel address LEDs mirror the bus. `LDAX D` reads memory
+at the address held in the DE register pair, so while the tight
+`ldax d` loop runs, register D (the "display byte" holding the lit
+bit) appears on the upper 8 address LEDs (A15–A8). The program toggles
+no output port at all — the LEDs *are* its display.
+
+The simulator did not model the address bus. `Sim8800.step()` in
+`js/sim8800.js` refreshed the address LEDs only from the program
+counter. Since the whole program lives below address `0018h`, the high
+byte of PC is always zero, so A15–A8 stayed dark and the game was
+invisible. (The input half of the game was never broken: `IN 0FFh`
+correctly reads the high 8 address switches.)
+
+## The workaround suggested in the issue thread
+
+A commenter (XujieSi) suggested patching the LED refresh to
+`cpu.pc | cpu.d * 256`, i.e. always OR register D onto the upper
+address LEDs. That makes Kill the Bit visible, but it corrupts the
+address display of every other program (any program running above
+address `00FFh`, or simply using D for data, would light bogus address
+LEDs). The commenter noted the systematic fix is to check whether the
+current instruction is actually `ldax d`.
+
+## The fix
+
+`Sim8800.step()` now executes the batch of cycles one instruction at a
+time and watches the opcode about to run. When `LDAX B` (`0Ah`) or
+`LDAX D` (`1Ah`) executes, the address it reads (the BC/DE register
+pair) is shown on the address LEDs at the end of the batch — emulating
+the address bus side effect the game depends on. For any other
+program, the LEDs show PC exactly as before.
+
+In addition, the clock ticker now computes each batch from the wall
+time elapsed since the previous tick instead of a fixed 1 ms quantum.
+Browsers clamp nested `setTimeout` to ~4 ms, which made the "1 MHz"
+CPU effectively run at ~250 kHz, so the bit crawled four times slower
+than on real hardware. With the fix the game plays at its authentic
+speed (the bit advances roughly every 0.23 s).
+
+All other panel features (EXAMINE / DEPOSIT / RESET / single step,
+port I/O, the debugger dumps, both `index.html` and `text-mode.html`)
+are unchanged, and are now covered by unit tests in `tests/`
+(`npm test`, requires Node.js 18+; no dependencies).
+
+## How to run Kill the Bit
+
+### Quick way (Debugger tab)
+
+1. Open `index.html`, switch the machine ON.
+2. Open the *Debugger* tab and load this hex string with *LOAD DATA*:
+   ```
+   21 00 00 16 80 01 0E 00 1A 1A 1A 1A 09 D2 08 00 DB FF AA 0F 57 C3 08 00
+   ```
+3. Make sure all 16 address switches are down, go back to the
+   *Simulator* tab, click *RESET*, then *RUN*.
+
+### Authentic way (front panel switches)
+
+With the machine ON, deposit the program in octal: set A7–A0 to the
+first value `041`, click *DEPOSIT*, then enter each following value
+and click *DEPOSIT NEXT*:
+
+```
+000: 041 000 000 026 200 001 016 000
+010: 032 032 032 032 011 322 010 000
+020: 333 377 252 017 127 303 010 000
+```
+
+Then lower all switches, click *RESET*, and *RUN*.
+
+### Playing
+
+A single lit bit rotates across the upper 8 address LEDs (A15–A8).
+Kill it by flipping the sense switch (S15–S8) directly under the lit
+LED at the right moment — then flip it back down. If you miss, the
+XOR turns another bit on. You win when all upper LEDs are dark.
+`lxi b,0eh` at address `0005` sets the speed: a higher value makes the
+bit rotate faster.
+
+**Why you must flip the switch back down quickly:** the game loop runs
+`IN 0FFh; XRA D; RRC` roughly every 0.23 s, and the XOR does not
+"test" your switch — it unconditionally *flips* the display bit at
+every position where a switch is up, on every pass. The first pass
+kills the lit bit, but if the switch is still up on the next pass it
+flips that (now dark) position back on, injecting a fresh bit, and the
+rotation smears the new bits across the row. Leave a switch up for a
+couple of seconds and the display fills with lit bits — this is the
+game's intended punishment mechanic, not a simulator bug, which is why
+the original 1975 listing warns: *"Quickly toggle the switch, don't
+leave the switch in the up position."* To count as a kill, the switch
+must go up and back down within a single loop pass.

--- a/js/sim8800.js
+++ b/js/sim8800.js
@@ -56,6 +56,7 @@ class Sim8800 {
         this.isPoweredOn = false;
         this.isRunning = false;
         this.lastAddress = 0;
+        this.lastTickTime = 0;
         this.initMem();
         CPU8080.init(this.getWriteByteCallback(),
                      this.getReadByteCallback(),
@@ -265,7 +266,16 @@ class Sim8800 {
         var self = this;
         return function(timestamp) {
             if (self.isRunning) {
-                var cycles = self.clockRate / 1000;
+                // Computes the number of cycles based on the wall time
+                // elapsed since the last tick, so that the simulated CPU
+                // runs at clockRate even when the browser clamps timers
+                // to a coarse resolution. The batch is capped in case
+                // the timer was suspended for a long time.
+                var now = Date.now();
+                var elapsed = Math.min(Math.max(now - self.lastTickTime, 1),
+                                       100);
+                self.lastTickTime = now;
+                var cycles = self.clockRate * elapsed / 1000;
                 self.step(cycles);
                 window.setTimeout(self.getClockTickerCallback(), 1);
             }
@@ -362,6 +372,7 @@ class Sim8800 {
         if (this.setWaitLedCallback) {
             this.setWaitLedCallback(this.isRunning);
         }
+        this.lastTickTime = Date.now();
         window.setTimeout(this.getClockTickerCallback(), 1);
     }
 
@@ -372,12 +383,39 @@ class Sim8800 {
     step(cycles) {
         if (!this.isPoweredOn)
             return;
-        CPU8080.steps(cycles);
+        // Runs instruction by instruction, watching for LDAX. On a
+        // real Altair 8800, the memory read cycle of LDAX B/D puts
+        // the BC/DE register pair on the address bus, hence on the
+        // address LEDs. Classic programs like Kill the Bit rely on
+        // this side effect to animate the high address LEDs. See
+        // https://github.com/wixette/8800-simulator/issues/1
+        var ldaxAddress = null;
+        var executed = 0;
+        while (executed < cycles) {
+            let cpu = CPU8080.status();
+            let opcode = this.mem[cpu.pc % this.mem.length];
+            let before = CPU8080.T();
+            CPU8080.steps(1);
+            let consumed = CPU8080.T() - before;
+            executed += consumed;
+            // A halted CPU consumes 1 cycle per step without
+            // executing the opcode at PC.
+            if (consumed > 1) {
+                if (opcode == 0x0a) {
+                    /* LDAX B */
+                    ldaxAddress = (cpu.b << 8) | cpu.c;
+                } else if (opcode == 0x1a) {
+                    /* LDAX D */
+                    ldaxAddress = (cpu.d << 8) | cpu.e;
+                }
+            }
+        }
         this.dumpCpu();
         this.dumpMem();
         if (this.setAddressLedsCallback) {
             let cpu = CPU8080.status();
-            let bits = Sim8800.parseBits(cpu.pc, 16);
+            let address = ldaxAddress != null ? ldaxAddress : cpu.pc;
+            let bits = Sim8800.parseBits(address, 16);
             this.setAddressLedsCallback(bits);
         }
     }
@@ -444,3 +482,9 @@ class Sim8800 {
         this.deposit();
     }
 };
+
+// Exports the class for unit tests when running in Node.js. This has
+// no effect when the script is loaded in a browser.
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = Sim8800;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "8800-simulator",
+  "version": "1.0.0",
+  "private": true,
+  "description": "A JavaScript simulator to demonstrate the front panel operations of Altair 8800.",
+  "license": "Apache-2.0",
+  "scripts": {
+    "test": "node --test \"tests/**/*.test.js\""
+  }
+}

--- a/tests/cpu8080.test.js
+++ b/tests/cpu8080.test.js
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for the 8080 CPU core (js/8080.js), focusing on the
+ * instructions that the front panel demos and Kill the Bit rely on.
+ *
+ * Run with: node --test tests/
+ */
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const CPU8080 = require('../js/8080.js');
+
+/**
+ * Initializes the CPU singleton with a 64KB memory preloaded with the
+ * given program at address 0.
+ */
+function makeMachine(program) {
+    const machine = {
+        mem: new Array(65536).fill(0),
+        inputValue: 0,
+        outputs: {},
+    };
+    program.forEach((byte, i) => { machine.mem[i] = byte; });
+    CPU8080.init(
+        (addr, value) => { machine.mem[addr] = value; },
+        (addr) => machine.mem[addr],
+        null,
+        (port, value) => { machine.outputs[port] = value; },
+        (port) => machine.inputValue);
+    return machine;
+}
+
+test('LXI loads 16-bit immediates into register pairs', () => {
+    makeMachine([0x21, 0x34, 0x12,   // LXI H,1234h
+                 0x01, 0x0e, 0x00]); // LXI B,000Eh
+    CPU8080.steps(20);
+    const cpu = CPU8080.status();
+    assert.strictEqual(cpu.h, 0x12);
+    assert.strictEqual(cpu.l, 0x34);
+    assert.strictEqual(cpu.b, 0x00);
+    assert.strictEqual(cpu.c, 0x0e);
+});
+
+test('MVI and LDAX D load A from the address in DE', () => {
+    const machine = makeMachine([0x16, 0x12,   // MVI D,12h
+                                 0x1e, 0x34,   // MVI E,34h
+                                 0x1a]);       // LDAX D
+    machine.mem[0x1234] = 0xab;
+    CPU8080.steps(21);
+    const cpu = CPU8080.status();
+    assert.strictEqual(cpu.d, 0x12);
+    assert.strictEqual(cpu.e, 0x34);
+    assert.strictEqual(cpu.a, 0xab);
+});
+
+test('DAD B adds BC to HL and sets carry on 16-bit overflow', () => {
+    makeMachine([0x21, 0xff, 0xff,   // LXI H,FFFFh
+                 0x01, 0x0e, 0x00,   // LXI B,000Eh
+                 0x09]);             // DAD B
+    CPU8080.steps(31);
+    const cpu = CPU8080.status();
+    assert.strictEqual((cpu.h << 8) | cpu.l, 0x000d);
+    assert.strictEqual(cpu.f & 0x01, 0x01, 'carry flag should be set');
+});
+
+test('DAD B leaves carry clear without 16-bit overflow', () => {
+    makeMachine([0x21, 0x00, 0x00,   // LXI H,0000h
+                 0x01, 0x0e, 0x00,   // LXI B,000Eh
+                 0x09]);             // DAD B
+    CPU8080.steps(31);
+    const cpu = CPU8080.status();
+    assert.strictEqual((cpu.h << 8) | cpu.l, 0x000e);
+    assert.strictEqual(cpu.f & 0x01, 0x00, 'carry flag should be clear');
+});
+
+test('JNC jumps only when carry is clear', () => {
+    // Carry clear: JNC takes the jump.
+    makeMachine([0xd2, 0x10, 0x00]); // JNC 0010h
+    CPU8080.steps(10);
+    assert.strictEqual(CPU8080.status().pc, 0x0010);
+
+    // Carry set (via RRC of 01h): JNC falls through.
+    makeMachine([0x3e, 0x01,         // MVI A,01h
+                 0x0f,               // RRC (sets carry)
+                 0xd2, 0x10, 0x00]); // JNC 0010h
+    CPU8080.steps(21);
+    assert.strictEqual(CPU8080.status().pc, 0x0006);
+});
+
+test('RRC rotates A right with wrap-around', () => {
+    makeMachine([0x3e, 0x80,   // MVI A,80h
+                 0x0f]);       // RRC
+    CPU8080.steps(11);
+    assert.strictEqual(CPU8080.status().a, 0x40);
+
+    makeMachine([0x3e, 0x01,   // MVI A,01h
+                 0x0f]);       // RRC
+    CPU8080.steps(11);
+    assert.strictEqual(CPU8080.status().a, 0x80);
+});
+
+test('XRA D xors A with D', () => {
+    makeMachine([0x3e, 0xff,   // MVI A,FFh
+                 0x16, 0x0f,   // MVI D,0Fh
+                 0xaa]);       // XRA D
+    CPU8080.steps(18);
+    assert.strictEqual(CPU8080.status().a, 0xf0);
+});
+
+test('MOV D,A copies A to D', () => {
+    makeMachine([0x3e, 0x5a,   // MVI A,5Ah
+                 0x57]);       // MOV D,A
+    CPU8080.steps(12);
+    assert.strictEqual(CPU8080.status().d, 0x5a);
+});
+
+test('IN and OUT use the port callbacks', () => {
+    const machine = makeMachine([0xdb, 0xff,   // IN FFh
+                                 0xd3, 0xff]); // OUT FFh
+    machine.inputValue = 0xc3;
+    CPU8080.steps(20);
+    assert.strictEqual(CPU8080.status().a, 0xc3);
+    assert.strictEqual(machine.outputs[0xff], 0xc3);
+});
+
+test('memory writes go through the write callback (STA)', () => {
+    const machine = makeMachine([0x3e, 0x77,         // MVI A,77h
+                                 0x32, 0x80, 0x00]); // STA 0080h
+    CPU8080.steps(20);
+    assert.strictEqual(machine.mem[0x0080], 0x77);
+});

--- a/tests/fixture.js
+++ b/tests/fixture.js
@@ -1,0 +1,73 @@
+/**
+ * Shared test fixture: loads the browser-oriented scripts into Node.js
+ * and wires Sim8800 instances to fake callbacks that record the last
+ * values they received.
+ */
+'use strict';
+
+// sim8800.js expects these browser globals.
+global.CPU8080 = require('../js/8080.js');
+global.window = {
+    pendingTimers: [],
+    setTimeout: function(callback, delay) {
+        global.window.pendingTimers.push({callback: callback, delay: delay});
+    },
+};
+
+const Sim8800 = require('../js/sim8800.js');
+
+/** Runs and clears all timers captured by the fake window.setTimeout. */
+function flushTimers() {
+    const timers = global.window.pendingTimers.splice(0);
+    for (const timer of timers) {
+        timer.callback();
+    }
+}
+
+/**
+ * Creates a Sim8800 wired to recording fake callbacks.
+ * @return {{sim: Sim8800, state: Object}}
+ */
+function createSim(memSize = 256, clockRate = 1000000) {
+    const state = {
+        addressLeds: null,    // Array of 16 bits, LSB first.
+        dataLeds: null,       // Array of 8 bits, LSB first.
+        waitLedArg: null,     // Last raw argument of setWaitLedCallback.
+        statusLedsArg: null,  // Last raw argument of setStatusLedsCallback.
+        inputWord: 0,         // The value the address switches report.
+        cpuDump: null,
+        memDump: null,
+    };
+    const sim = new Sim8800(
+        memSize, clockRate,
+        (bits) => { state.addressLeds = bits.slice(); },
+        (bits) => { state.dataLeds = bits.slice(); },
+        (isRunning) => { state.waitLedArg = isRunning; },
+        (isPoweredOn) => { state.statusLedsArg = isPoweredOn; },
+        () => state.inputWord,
+        (html) => { state.cpuDump = html; },
+        (html) => { state.memDump = html; });
+    return {sim: sim, state: state};
+}
+
+/** Converts an LSB-first bit array to a number. */
+function bitsToNumber(bits) {
+    let n = 0;
+    for (let i = 0; i < bits.length; i++) {
+        n |= bits[i] << i;
+    }
+    return n;
+}
+
+/** Returns the number shown on the high 8 address LEDs (A15-A8). */
+function highAddressLeds(state) {
+    return bitsToNumber(state.addressLeds.slice(8));
+}
+
+module.exports = {
+    Sim8800: Sim8800,
+    createSim: createSim,
+    flushTimers: flushTimers,
+    bitsToNumber: bitsToNumber,
+    highAddressLeds: highAddressLeds,
+};

--- a/tests/sim8800.test.js
+++ b/tests/sim8800.test.js
@@ -1,0 +1,236 @@
+/**
+ * Unit tests for the front panel simulator (js/sim8800.js), covering
+ * the existing panel features and the Kill the Bit fix (issue #1).
+ *
+ * Run with: node --test tests/
+ */
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+const {Sim8800, createSim, flushTimers, bitsToNumber, highAddressLeds} =
+      require('./fixture.js');
+
+/** The demo programs from asm/tiny_programs.md. */
+const ADDER = '3a 80 00 47 3a 81 00 80 32 82 00 c3 00 00';
+const PATTERN_SHIFT = '3e 8c d3 ff 0f c3 02 00';
+const IO_ECHO = 'db ff d3 ff c3 00 00';
+
+/** Kill the Bit by Dean McDaniel, 1975. See doc/kill_the_bit.md. */
+const KILL_THE_BIT =
+      '21 00 00 16 80 01 0e 00 1a 1a 1a 1a 09 d2 08 00 db ff aa 0f 57 c3 08 00';
+
+/** Creates a powered-on simulator with the reset LED blink flushed. */
+function poweredOnSim() {
+    const fixture = createSim();
+    fixture.sim.powerOn();
+    flushTimers();
+    return fixture;
+}
+
+test('static helpers: toHex and parseBits', () => {
+    assert.strictEqual(Sim8800.toHex(0x5, 2), '05');
+    assert.strictEqual(Sim8800.toHex(0xabc, 4), '0abc');
+    assert.deepStrictEqual(Sim8800.parseBits(0x80, 8),
+                           [0, 0, 0, 0, 0, 0, 0, 1]);
+    assert.deepStrictEqual(Sim8800.parseBits(0x03, 4), [1, 1, 0, 0]);
+});
+
+test('powerOn initializes memory, LEDs and dumps', () => {
+    const {sim, state} = createSim();
+    sim.powerOn();
+    assert.strictEqual(sim.isPoweredOn, true);
+    assert.strictEqual(state.statusLedsArg, true);
+    assert.strictEqual(state.waitLedArg, false);
+    assert.ok(sim.mem.every((byte) => byte == 0));
+    // reset() blinks all LEDs on, then a timer turns them off.
+    assert.strictEqual(bitsToNumber(state.addressLeds), 0xffff);
+    assert.strictEqual(bitsToNumber(state.dataLeds), 0xff);
+    flushTimers();
+    assert.strictEqual(bitsToNumber(state.addressLeds), 0);
+    assert.strictEqual(bitsToNumber(state.dataLeds), 0);
+    assert.ok(state.cpuDump.includes('PC = 0000'));
+    assert.ok(state.memDump.includes('0000'));
+});
+
+test('powerOff clears LEDs and dumps', () => {
+    const {sim, state} = poweredOnSim();
+    sim.powerOff();
+    assert.strictEqual(sim.isPoweredOn, false);
+    assert.strictEqual(state.statusLedsArg, false);
+    assert.strictEqual(bitsToNumber(state.addressLeds), 0);
+    assert.strictEqual(bitsToNumber(state.dataLeds), 0);
+    assert.strictEqual(state.cpuDump, '');
+    assert.strictEqual(state.memDump, '');
+});
+
+test('controls are no-ops while powered off', () => {
+    const {sim, state} = createSim();
+    state.inputWord = 0x55;
+    sim.loadDataAsHexString(0, 'c3 00 00');
+    sim.loadData(0, [1, 2, 3]);
+    sim.deposit();
+    sim.examine();
+    sim.step(100);
+    sim.start();
+    assert.ok(sim.mem.every((byte) => byte == 0 || byte === undefined));
+    assert.strictEqual(sim.isRunning, false);
+    assert.strictEqual(state.addressLeds, null);
+});
+
+test('loadData and loadDataAsHexString write into memory', () => {
+    const {sim} = poweredOnSim();
+    sim.loadData(0x80, [1, 2]);
+    assert.strictEqual(sim.mem[0x80], 1);
+    assert.strictEqual(sim.mem[0x81], 2);
+    sim.loadDataAsHexString(0, 'c3 00 00');
+    assert.deepStrictEqual(sim.mem.slice(0, 3), [0xc3, 0, 0]);
+});
+
+test('examine and deposit drive LEDs and memory like the real panel', () => {
+    const {sim, state} = poweredOnSim();
+
+    // EXAMINE address 0x34.
+    state.inputWord = 0x34;
+    sim.examine();
+    assert.strictEqual(bitsToNumber(state.addressLeds), 0x34);
+    assert.strictEqual(bitsToNumber(state.dataLeds), 0x00);
+
+    // DEPOSIT 0x55 at the examined address. Only the low 8 input bits
+    // are considered.
+    state.inputWord = 0xff55;
+    sim.deposit();
+    assert.strictEqual(sim.mem[0x34], 0x55);
+    assert.strictEqual(bitsToNumber(state.dataLeds), 0x55);
+
+    // DEPOSIT NEXT writes to the following address.
+    state.inputWord = 0x66;
+    sim.depositNext();
+    assert.strictEqual(sim.mem[0x35], 0x66);
+    assert.strictEqual(bitsToNumber(state.addressLeds), 0x35);
+
+    // EXAMINE NEXT moves to the following address.
+    sim.examineNext();
+    assert.strictEqual(bitsToNumber(state.addressLeds), 0x36);
+    assert.strictEqual(bitsToNumber(state.dataLeds), 0x00);
+});
+
+test('start/stop toggle the running state and the WAIT LED', () => {
+    const {sim, state} = poweredOnSim();
+    sim.start();
+    assert.strictEqual(sim.isRunning, true);
+    assert.strictEqual(state.waitLedArg, true);
+    sim.stop();
+    assert.strictEqual(sim.isRunning, false);
+    assert.strictEqual(state.waitLedArg, false);
+    flushTimers();  // The pending clock tick must do nothing once stopped.
+    assert.strictEqual(sim.isRunning, false);
+});
+
+test('reset stops the CPU and resets PC to 0', () => {
+    const {sim, state} = poweredOnSim();
+    sim.loadDataAsHexString(0, 'c3 00 00');  // JMP 0000h
+    sim.step(50);
+    sim.start();
+    sim.reset();
+    assert.strictEqual(sim.isRunning, false);
+    flushTimers();
+    assert.ok(state.cpuDump.includes('PC = 0000'));
+});
+
+test('step shows PC on the address LEDs for ordinary programs', () => {
+    const {sim, state} = poweredOnSim();
+    // Memory is all NOPs; two NOPs take 8 cycles.
+    sim.step(8);
+    assert.strictEqual(bitsToNumber(state.addressLeds), 2);
+});
+
+test('adder demo: 1 + 2 = 3', () => {
+    const {sim} = poweredOnSim();
+    sim.loadDataAsHexString(0, ADDER);
+    sim.loadData(0x80, [1, 2]);
+    sim.step(200);
+    assert.strictEqual(sim.mem[0x82], 3);
+});
+
+test('pattern shift demo: OUT FFh drives the data LEDs', () => {
+    const {sim, state} = poweredOnSim();
+    sim.loadDataAsHexString(0, PATTERN_SHIFT);
+    sim.step(17);  // MVI A,8Ch (7) + OUT FFh (10).
+    assert.strictEqual(bitsToNumber(state.dataLeds), 0x8c);
+});
+
+test('I/O echo demo: IN FFh reads the high 8 address switches', () => {
+    const {sim, state} = poweredOnSim();
+    sim.loadDataAsHexString(0, IO_ECHO);
+    state.inputWord = 0xab12;  // Sense switches are A15-A8.
+    sim.step(20);              // IN FFh (10) + OUT FFh (10).
+    assert.strictEqual(bitsToNumber(state.dataLeds), 0xab);
+});
+
+test('IN from ports other than FFh reads 0', () => {
+    const {sim, state} = poweredOnSim();
+    sim.loadDataAsHexString(0, 'db 12 d3 ff');  // IN 12h; OUT FFh.
+    state.inputWord = 0xffff;
+    sim.step(20);
+    assert.strictEqual(bitsToNumber(state.dataLeds), 0);
+});
+
+test('kill the bit: LDAX D lights the high address LEDs (issue #1)', () => {
+    const {sim, state} = poweredOnSim();
+    sim.loadDataAsHexString(0, KILL_THE_BIT);
+    // A short run reaches the LDAX D display loop; the initial bit
+    // pattern in D is 80h.
+    sim.step(200);
+    assert.strictEqual(highAddressLeds(state), 0x80);
+});
+
+test('kill the bit: the lit bit rotates over time', () => {
+    const {sim, state} = poweredOnSim();
+    sim.loadDataAsHexString(0, KILL_THE_BIT);
+    // One full delay loop takes roughly 230K cycles, after which the
+    // bit moves from A15 to A14.
+    let rotated = false;
+    for (let i = 0; i < 20 && !rotated; i++) {
+        sim.step(50000);
+        if (highAddressLeds(state) == 0x40) {
+            rotated = true;
+        }
+    }
+    assert.ok(rotated, 'the lit bit should rotate from A15 to A14');
+});
+
+test('kill the bit: raising the matching sense switch kills the bit', () => {
+    const {sim, state} = poweredOnSim();
+    sim.loadDataAsHexString(0, KILL_THE_BIT);
+    sim.step(200);
+    const litBit = highAddressLeds(state);
+    assert.notStrictEqual(litBit, 0);
+
+    // Raise the sense switch right over the lit bit and run until the
+    // program reads it (IN FFh; XRA D zeroes the display register).
+    state.inputWord = litBit << 8;
+    let killed = false;
+    for (let i = 0; i < 300 && !killed; i++) {
+        sim.step(2000);
+        if (global.CPU8080.status().d == 0) {
+            killed = true;
+        }
+    }
+    assert.ok(killed, 'XRA D should zero the display register');
+
+    // Lower the switch; with no bits left the high LEDs stay dark.
+    state.inputWord = 0;
+    sim.step(300000);
+    assert.strictEqual(highAddressLeds(state), 0);
+});
+
+test('single step on an LDAX D instruction shows DE on the LEDs', () => {
+    const {sim, state} = poweredOnSim();
+    sim.loadDataAsHexString(0, '16 12 1e 34 1a');  // MVI D; MVI E; LDAX D.
+    sim.step(1);  // MVI D,12h
+    sim.step(1);  // MVI E,34h
+    assert.strictEqual(bitsToNumber(state.addressLeds), 4);  // PC.
+    sim.step(1);  // LDAX D: the address bus shows DE.
+    assert.strictEqual(bitsToNumber(state.addressLeds), 0x1234);
+});


### PR DESCRIPTION
The address LEDs were driven only by the PC, so Kill the Bit - which displays its game state by looping LDAX D to put register D on the upper 8 address lines - showed nothing. Sim8800.step() now executes instruction by instruction and shows the BC/DE register pair on the address LEDs when LDAX B/D executes; all other programs still display the PC as before.

Also pace the clock ticker by elapsed wall time instead of a fixed 1ms quantum, so the CPU runs at the declared 1MHz despite browser timer clamping (the game previously ran ~4x slow).

Add doc/kill_the_bit.md documenting the issue, root cause, fix, and how to load and play the game, plus a dependency-free Node test suite (npm test) covering the 8080 core, all existing panel features, and the game behavior.

Fixes #1