### PR TITLE
Show the data bus byte on the data LEDs during single step (#2)

### DIFF
--- a/js/panel.js
+++ b/js/panel.js
@@ -40,7 +40,7 @@ panel.onRun = function() {
  * When SINGLE STEP switch is pressed.
  */
 panel.onSingle = function() {
-    panel.sim.step(1);
+    panel.sim.singleStep();
 };
 
 /**

--- a/js/sim8800.js
+++ b/js/sim8800.js
@@ -379,6 +379,7 @@ class Sim8800 {
     /**
      * Runs a given number of CPU cycles.
      * @param {number} cycles The number of CPU cycles to step on.
+     * @return {number|undefined} The address shown on the address LEDs.
      */
     step(cycles) {
         if (!this.isPoweredOn)
@@ -412,11 +413,31 @@ class Sim8800 {
         }
         this.dumpCpu();
         this.dumpMem();
+        var address = ldaxAddress != null ? ldaxAddress : CPU8080.status().pc;
         if (this.setAddressLedsCallback) {
-            let cpu = CPU8080.status();
-            let address = ldaxAddress != null ? ldaxAddress : cpu.pc;
             let bits = Sim8800.parseBits(address, 16);
             this.setAddressLedsCallback(bits);
+        }
+        return address;
+    }
+
+    /**
+     * Runs a single instruction, for the SINGLE STEP switch on the
+     * front panel. Besides the address LEDs, the data LEDs are
+     * updated with the memory byte at the displayed address - the
+     * next opcode to be fetched, or the byte just read by LDAX -
+     * similar to how a real Altair 8800 shows the data bus contents
+     * while stepping. The data LEDs are not touched when the CPU is
+     * free-running, so that OUT FFh keeps full control of them.
+     */
+    singleStep() {
+        if (!this.isPoweredOn)
+            return;
+        var address = this.step(1);
+        if (this.setDataLedsCallback) {
+            let bits = Sim8800.parseBits(this.mem[address % this.mem.length],
+                                         8);
+            this.setDataLedsCallback(bits);
         }
     }
 

--- a/tests/sim8800.test.js
+++ b/tests/sim8800.test.js
@@ -234,3 +234,43 @@ test('single step on an LDAX D instruction shows DE on the LEDs', () => {
     sim.step(1);  // LDAX D: the address bus shows DE.
     assert.strictEqual(bitsToNumber(state.addressLeds), 0x1234);
 });
+
+test('singleStep shows the next opcode on the data LEDs (issue #2)', () => {
+    const {sim, state} = poweredOnSim();
+    sim.loadDataAsHexString(0, ADDER);  // 3a 80 00 47 3a 81 00 80 ...
+    sim.singleStep();  // LDA 0080h; PC is now 3, next opcode is MOV B,A.
+    assert.strictEqual(bitsToNumber(state.addressLeds), 3);
+    assert.strictEqual(bitsToNumber(state.dataLeds), 0x47);
+    sim.singleStep();  // MOV B,A; next opcode is LDA.
+    assert.strictEqual(bitsToNumber(state.addressLeds), 4);
+    assert.strictEqual(bitsToNumber(state.dataLeds), 0x3a);
+});
+
+test('singleStep on LDAX D shows the byte read at DE (issue #2)', () => {
+    const {sim, state} = poweredOnSim();
+    sim.loadDataAsHexString(0, '16 00 1e 80 1a');  // MVI D,0; MVI E,80h; LDAX D.
+    sim.loadData(0x80, [0xa5]);
+    sim.singleStep();  // MVI D,00h
+    sim.singleStep();  // MVI E,80h
+    sim.singleStep();  // LDAX D: address LEDs show DE, data LEDs the byte read.
+    assert.strictEqual(bitsToNumber(state.addressLeds), 0x0080);
+    assert.strictEqual(bitsToNumber(state.dataLeds), 0xa5);
+});
+
+test('singleStep is a no-op while powered off', () => {
+    const {sim, state} = createSim();
+    sim.singleStep();
+    assert.strictEqual(state.addressLeds, null);
+    assert.strictEqual(state.dataLeds, null);
+});
+
+test('free-running step leaves the data LEDs to OUT FFh', () => {
+    const {sim, state} = poweredOnSim();
+    sim.loadDataAsHexString(0, PATTERN_SHIFT);
+    sim.step(17);  // MVI A,8Ch + OUT FFh: data LEDs show 8Ch.
+    sim.step(100); // Keep running: only OUT may change the data LEDs.
+    const shown = bitsToNumber(state.dataLeds);
+    const validOutputs = [0x8c, 0x46, 0x23, 0x91, 0xc8, 0x64, 0x32, 0x19];
+    assert.ok(validOutputs.includes(shown),
+              'data LEDs must show a rotation of 8Ch, got ' + shown);
+});

--- a/text-mode.html
+++ b/text-mode.html
@@ -266,7 +266,7 @@
      }
 
      function singleStep() {
-       sim.step(1);
+       sim.singleStep();
      }
 
      function stop() {


### PR DESCRIPTION
SINGLE STEP executed one instruction and advanced the address LEDs, but the data LEDs never changed, which made stepping look broken compared to a real Altair 8800 where the data LEDs mirror the data bus on every machine cycle.

Add Sim8800.singleStep(), used by both the panel UI and the text-mode UI: after executing one instruction it shows the memory byte at the displayed address on the data LEDs - the next opcode to be fetched, or the byte just read when the instruction was LDAX B/D. The data LEDs remain untouched while free-running, so OUT FFh keeps full control of them.